### PR TITLE
Impl 設定ファイルに基づき、*.rpfのコンパイルを行うよう変更した

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-init-tools:
-	docker-compose -f ./docker/dev/docker-compose.yml run --rm devenv sh ./eng/init-tools.sh
-
 gen-code:
 	docker-compose -f ./docker/dev/docker-compose.yml run --rm devenv sh ./eng/gen-code.sh
 

--- a/eng/gen-code.sh
+++ b/eng/gen-code.sh
@@ -2,20 +2,6 @@
 
 DOTNET_CLI_TELEMETRY_OPTOUT=1
 
-BIN_DIR="$PWD/bin/tools/linux"
-TOOL_PATH="$BIN_DIR/Omnius.Core.RocketPack.DefinitionCompiler/Omnius.Core.RocketPack.DefinitionCompiler"
-INCLUDE="$PWD/rpfs/**/*.rpf"
-
-"$TOOL_PATH" compile -s "$PWD/rpfs/FormatterBenchmarks/FormatterBenchmarks.Internal.rpf" -i "$INCLUDE" -o "$PWD/perf/FormatterBenchmarks/Internal/_RocketPack/_Generated.cs"
-
-"$TOOL_PATH" compile -s "$PWD/rpfs/Omnius.Core.Cryptography/Omnius.Core.Cryptography.rpf" -i "$INCLUDE" -o "$PWD/src/Omnius.Core.Cryptography/_RocketPack/_Generated.cs"
-
-"$TOOL_PATH" compile -s "$PWD/rpfs/Omnius.Core.Network/Omnius.Core.Network.rpf" -i "$INCLUDE" -o "$PWD/src/Omnius.Core.Network/_RocketPack/_Generated.cs"
-"$TOOL_PATH" compile -s "$PWD/rpfs/Omnius.Core.Network/Omnius.Core.Network.Connections.Secure.rpf" -i "$INCLUDE" -o "$PWD/src/Omnius.Core.Network/Connections/Secure/_RocketPack/_Generated.cs"
-"$TOOL_PATH" compile -s "$PWD/rpfs/Omnius.Core.Network/Omnius.Core.Network.Connections.Secure.Internal.rpf" -i "$INCLUDE" -o "$PWD/src/Omnius.Core.Network/Connections/Secure/Internal/_RocketPack/_Generated.cs"
-"$TOOL_PATH" compile -s "$PWD/rpfs/Omnius.Core.Network/Omnius.Core.Network.Connections.Secure.V1.Internal.rpf" -i "$INCLUDE" -o "$PWD/src/Omnius.Core.Network/Connections/Secure/V1/Internal/_RocketPack/_Generated.cs"
-
-"$TOOL_PATH" compile -s "$PWD/rpfs/Omnius.Core.RocketPack.Remoting/Omnius.Core.RocketPack.Remoting.rpf" -i "$INCLUDE" -o "$PWD/src/Omnius.Core.RocketPack.Remoting/_RocketPack/_Generated.cs"
-
-"$TOOL_PATH" compile -s "$PWD/rpfs/Omnius.Core.RocketPack.Tests/Omnius.Core.RocketPack.Tests.Internal.rpf" -o "$PWD/test/Omnius.Core.RocketPack.Tests/Internal/_RocketPack/_Generated.cs"
-"$TOOL_PATH" compile -s "$PWD/rpfs/Omnius.Core.RocketPack.Remoting.Tests/Omnius.Core.RocketPack.Remoting.Tests.Internal.rpf" -o "$PWD/test/Omnius.Core.RocketPack.Remoting.Tests/Internal/_RocketPack/_Generated.cs"
+# *.rpf
+RPFC_PATH="$PWD/src/Omnius.Core.RocketPack.DefinitionCompiler"
+dotnet run -p $RPFC_PATH -- -c "$PWD/rpfs/config.yml"

--- a/eng/init-tools.sh
+++ b/eng/init-tools.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-DOTNET_CLI_TELEMETRY_OPTOUT=1
-
-BIN_DIR="$PWD/bin/tools/linux"
-BUILD_ARCHITECTURE=linux-x64
-
-mkdir "$BIN_DIR/Omnius.Core.RocketPack.DefinitionCompiler"
-dotnet publish "$PWD/src/Omnius.Core.RocketPack.DefinitionCompiler/Omnius.Core.RocketPack.DefinitionCompiler.csproj" --configuration Release --output "$BIN_DIR/Omnius.Core.RocketPack.DefinitionCompiler" --runtime $BUILD_ARCHITECTURE

--- a/rpfs/config.yml
+++ b/rpfs/config.yml
@@ -1,0 +1,23 @@
+- Includes:
+    - ./rpfs/**/*.rpf
+  CompileTargets:
+    - Input: ./rpfs/FormatterBenchmarks/FormatterBenchmarks.Internal.rpf
+      Output: ./perf/FormatterBenchmarks/Internal/_RocketPack/_Generated.cs
+    - Input: ./rpfs/Omnius.Core.Cryptography/Omnius.Core.Cryptography.rpf
+      Output: ./src/Omnius.Core.Cryptography/_RocketPack/_Generated.cs
+    - Input: ./rpfs/Omnius.Core.Network/Omnius.Core.Network.rpf
+      Output: ./src/Omnius.Core.Network/_RocketPack/_Generated.cs
+    - Input: ./rpfs/Omnius.Core.Network/Omnius.Core.Network.Connections.Secure.rpf
+      Output: ./src/Omnius.Core.Network/Connections/Secure/_RocketPack/_Generated.cs
+    - Input: ./rpfs/Omnius.Core.Network/Omnius.Core.Network.Connections.Secure.Internal.rpf
+      Output: ./src/Omnius.Core.Network/Connections/Secure/Internal/_RocketPack/_Generated.cs
+    - Input: ./rpfs/Omnius.Core.Network/Omnius.Core.Network.Connections.Secure.V1.Internal.rpf
+      Output: ./src/Omnius.Core.Network/Connections/Secure/V1/Internal/_RocketPack/_Generated.cs
+    - Input: ./rpfs/Omnius.Core.RocketPack.Remoting/Omnius.Core.RocketPack.Remoting.rpf
+      Output: ./src/Omnius.Core.RocketPack.Remoting/_RocketPack/_Generated.cs
+- Includes:
+  CompileTargets:
+    - Input: ./rpfs/Omnius.Core.RocketPack.Tests/Omnius.Core.RocketPack.Tests.Internal.rpf
+      Output: ./test/Omnius.Core.RocketPack.Tests/Internal/_RocketPack/_Generated.cs
+    - Input: ./rpfs/Omnius.Core.RocketPack.Remoting.Tests/Omnius.Core.RocketPack.Remoting.Tests.Internal.rpf
+      Output: ./test/Omnius.Core.RocketPack.Remoting.Tests/Internal/_RocketPack/_Generated.cs

--- a/src/Omnius.Core.RocketPack.DefinitionCompiler/Internal/YamlHelper.cs
+++ b/src/Omnius.Core.RocketPack.DefinitionCompiler/Internal/YamlHelper.cs
@@ -1,0 +1,40 @@
+using System.IO;
+using System.Text;
+using YamlDotNet;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Omnius.Core.RocketPack.DefinitionCompiler.Internal
+{
+    public static class YamlHelper
+    {
+        public static T ReadFile<T>(string path)
+        {
+            using var stream = new FileStream(path, FileMode.Open);
+            return ReadStream<T>(stream);
+        }
+
+        public static T ReadStream<T>(Stream stream)
+        {
+            var deserializer = new DeserializerBuilder()
+                .WithNamingConvention(PascalCaseNamingConvention.Instance)
+                .Build();
+            using var reader = new StreamReader(stream);
+            return deserializer.Deserialize<T>(reader);
+        }
+
+        public static void WriteFile(string path, object value)
+        {
+            using var stream = new FileStream(path, FileMode.Create);
+            WriteStream(stream, value);
+        }
+
+        public static void WriteStream(Stream stream, object value)
+        {
+            var serializer = new SerializerBuilder()
+                .Build();
+            using var writer = new StreamWriter(stream, new UTF8Encoding(false));
+            serializer.Serialize(writer, value);
+        }
+    }
+}

--- a/src/Omnius.Core.RocketPack.DefinitionCompiler/Models/Config.cs
+++ b/src/Omnius.Core.RocketPack.DefinitionCompiler/Models/Config.cs
@@ -1,0 +1,20 @@
+using System.IO;
+using System.Net;
+using Omnius.Core.RocketPack.DefinitionCompiler.Internal;
+
+namespace Omnius.Core.RocketPack.DefinitionCompiler.Models
+{
+    public class Config
+    {
+        public string[]? Includes { get; init; }
+
+        public CompileTargetConfig[]? CompileTargets { get; init; }
+    }
+
+    public class CompileTargetConfig
+    {
+        public string? Input { get; init; }
+
+        public string? Output { get; init; }
+    }
+}

--- a/src/Omnius.Core.RocketPack.DefinitionCompiler/Omnius.Core.RocketPack.DefinitionCompiler.csproj
+++ b/src/Omnius.Core.RocketPack.DefinitionCompiler/Omnius.Core.RocketPack.DefinitionCompiler.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
-    <ToolCommandName>rpdc</ToolCommandName>
+    <ToolCommandName>rpfc</ToolCommandName>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,6 +13,7 @@
     <PackageReference Include="NLog" Version="4.7.7" />
     <PackageReference Include="NLog.Config" Version="4.7.7" />
     <PackageReference Include="Sprache" Version="2.3.1" />
+    <PackageReference Include="YamlDotNet" Version="9.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Omnius.Core.RocketPack.DefinitionCompiler/packages.lock.any.json
+++ b/src/Omnius.Core.RocketPack.DefinitionCompiler/packages.lock.any.json
@@ -55,6 +55,12 @@
         "resolved": "1.1.118",
         "contentHash": "Onx6ovGSqXSK07n/0eM3ZusiNdB6cIlJdabQhWGgJp3Vooy9AaLS/tigeybOJAobqbtggTamoWndz72JscZBvw=="
       },
+      "YamlDotNet": {
+        "type": "Direct",
+        "requested": "[9.1.4, )",
+        "resolved": "9.1.4",
+        "contentHash": "dVVZVhQxTI4xTNc9YorE+RruBFPPYKP44kMijE6Z5OQQE7zK+SEmh2sPm091CrTYVz1jjIuXKIBm1kFLrlsQJg=="
+      },
       "Cocona.Core": {
         "type": "Transitive",
         "resolved": "1.5.0",

--- a/test/Omnius.Core.RocketPack.DefinitionCompiler.Tests/packages.lock.any.json
+++ b/test/Omnius.Core.RocketPack.DefinitionCompiler.Tests/packages.lock.any.json
@@ -1184,6 +1184,11 @@
           "xunit.extensibility.core": "[2.4.1]"
         }
       },
+      "YamlDotNet": {
+        "type": "Transitive",
+        "resolved": "9.1.4",
+        "contentHash": "dVVZVhQxTI4xTNc9YorE+RruBFPPYKP44kMijE6Z5OQQE7zK+SEmh2sPm091CrTYVz1jjIuXKIBm1kFLrlsQJg=="
+      },
       "omnius.core.rocketpack.definitioncompiler": {
         "type": "Project",
         "dependencies": {
@@ -1191,7 +1196,8 @@
           "Glob.cs": "5.0.224",
           "NLog": "4.7.7",
           "NLog.Config": "4.7.7",
-          "Sprache": "2.3.1"
+          "Sprache": "2.3.1",
+          "YamlDotNet": "9.1.4"
         }
       }
     }

--- a/test/Omnius.Core.RocketPack.Remoting.Tests/Internal/_RocketPack/_Generated.cs
+++ b/test/Omnius.Core.RocketPack.Remoting.Tests/Internal/_RocketPack/_Generated.cs
@@ -208,7 +208,7 @@ namespace Omnius.Core.RocketPack.Remoting.Tests.Internal
     }
     internal class TestService
     {
-        internal class Client : global::Omnius.Core.AsyncDisposableBase, global::Omnius.Core.RocketPack.Remoting.Tests.Internal.ITestService
+        public class Client : global::Omnius.Core.AsyncDisposableBase, global::Omnius.Core.RocketPack.Remoting.Tests.Internal.ITestService
         {
             private readonly global::Omnius.Core.Network.Connections.IConnection _connection;
             private readonly global::Omnius.Core.IBytesPool _bytesPool;
@@ -244,7 +244,7 @@ namespace Omnius.Core.RocketPack.Remoting.Tests.Internal
                 await function.CallActionAsync(cancellationToken);
             }
         }
-        internal class Server : global::Omnius.Core.AsyncDisposableBase
+        public class Server : global::Omnius.Core.AsyncDisposableBase
         {
             private readonly global::Omnius.Core.RocketPack.Remoting.Tests.Internal.ITestService _service;
             private readonly global::Omnius.Core.Network.Connections.IConnection _connection;


### PR DESCRIPTION
都度引数渡して実行するよりも、1プロセスで複数のコンパイルが完了するほうが実行速度が速かったため、この対応を行った。
事前にプロジェクトをコンパイルする必要がない程度に高速になったため、`make init-tools`は不要になった。
