### PR TITLE
Impl ReadOnlyListSlimにSliceメソッド追加

### DIFF
--- a/src/Omnius.Core.Collections/ReadOnlyListSlim.cs
+++ b/src/Omnius.Core.Collections/ReadOnlyListSlim.cs
@@ -22,6 +22,13 @@ namespace Omnius.Core.Collections
 
         public T this[int index] => _array[index];
 
+        public T[] Slice(int start, int length)
+        {
+            var slice = new T[length];
+            Array.Copy(_array, start, slice, 0, length);
+            return slice;
+        }
+
         public int Count => _array.Length;
 
         public Enumerator GetEnumerator()


### PR DESCRIPTION
Rangeに対応するため。

ref. https://docs.microsoft.com/ja-jp/dotnet/csharp/language-reference/proposals/csharp-8.0/ranges#implicit-range-support