### PR TITLE
fix: BatchAction

### DIFF
--- a/src/Omnius.Core.Net.Connections/Bridge/BridgeConnection.BatchAction.cs
+++ b/src/Omnius.Core.Net.Connections/Bridge/BridgeConnection.BatchAction.cs
@@ -15,9 +15,6 @@ namespace Omnius.Core.Net.Connections.Bridge
             private readonly ConnectionReceiver _receiver;
             private readonly IBandwidthLimiter? _senderBandwidthLimiter;
             private readonly IBandwidthLimiter? _receiverBandwidthLimiter;
-            private readonly Stopwatch _stopwatch;
-
-            private static readonly TimeSpan _interval = TimeSpan.FromMilliseconds(100);
 
             public BatchAction(ConnectionSender sender, ConnectionReceiver receiver, IBandwidthLimiter? senderBandwidthLimiter, IBandwidthLimiter? receiverBandwidthLimiter)
             {
@@ -25,28 +22,12 @@ namespace Omnius.Core.Net.Connections.Bridge
                 _receiver = receiver;
                 _senderBandwidthLimiter = senderBandwidthLimiter;
                 _receiverBandwidthLimiter = receiverBandwidthLimiter;
-                _stopwatch = Stopwatch.StartNew();
             }
 
-            public async ValueTask WaitAsync(CancellationToken cancellationToken = default)
+            public TimeSpan Interval { get; } = TimeSpan.FromMilliseconds(30);
+
+            public void Execute()
             {
-                try
-                {
-                    var delay = _interval - _stopwatch.Elapsed;
-                    if (delay <= TimeSpan.Zero) return;
-
-                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception e)
-                {
-                    _logger.Debug(e);
-                }
-            }
-
-            public void Run()
-            {
-                _stopwatch.Restart();
-
                 this.Send();
                 this.Receive();
             }

--- a/src/Omnius.Core.Net.Connections/Multiplexer/V1/Internal/ConnectionMultiplexer.BatchAction.cs
+++ b/src/Omnius.Core.Net.Connections/Multiplexer/V1/Internal/ConnectionMultiplexer.BatchAction.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,15 +17,9 @@ namespace Omnius.Core.Net.Connections.Multiplexer.V1.Internal
                 _connectionMultiplexer = connectionMultiplexer;
             }
 
-            public async ValueTask WaitAsync(CancellationToken cancellationToken = default)
-            {
-                var tasks = new List<Task>();
-                tasks.Add(_connectionMultiplexer.InternalWaitToSendAsync(cancellationToken).AsTask());
-                tasks.Add(_connectionMultiplexer.InternalWaitToReceiveAsync(cancellationToken).AsTask());
-                await Task.WhenAny(tasks.ToArray());
-            }
+            public TimeSpan Interval { get; } = TimeSpan.FromMilliseconds(100);
 
-            public void Run()
+            public void Execute()
             {
                 _connectionMultiplexer.InternalSend();
                 _connectionMultiplexer.InternalReceive();

--- a/src/Omnius.Core.Net.Connections/Multiplexer/V1/Internal/ConnectionMultiplexer.cs
+++ b/src/Omnius.Core.Net.Connections/Multiplexer/V1/Internal/ConnectionMultiplexer.cs
@@ -100,16 +100,6 @@ namespace Omnius.Core.Net.Connections.Multiplexer.V1.Internal
             _batchActionDispatcher.Register(_batchAction);
         }
 
-        private async ValueTask InternalWaitToSendAsync(CancellationToken cancellationToken = default)
-        {
-            await _connection.Sender.WaitToSendAsync(cancellationToken);
-        }
-
-        private async ValueTask InternalWaitToReceiveAsync(CancellationToken cancellationToken = default)
-        {
-            await _connection.Receiver.WaitToReceiveAsync(cancellationToken);
-        }
-
         private void InternalSend()
         {
             if (_sessionOptions is null) return;

--- a/src/Omnius.Core.Net.Connections/Secure/V1/Internal/SecureConnection.BatchAction.cs
+++ b/src/Omnius.Core.Net.Connections/Secure/V1/Internal/SecureConnection.BatchAction.cs
@@ -19,22 +19,9 @@ namespace Omnius.Core.Net.Connections.Secure.V1.Internal
                 _receiver = receiver;
             }
 
-            public async ValueTask WaitAsync(CancellationToken cancellationToken = default)
-            {
-                try
-                {
-                    var tasks = new List<Task>();
-                    tasks.Add(_sender.InternalWaitToSendAsync(cancellationToken).AsTask());
-                    tasks.Add(_receiver.InternalWaitToReceiveAsync(cancellationToken).AsTask());
-                    await Task.WhenAny(tasks);
-                }
-                catch (Exception e)
-                {
-                    _logger.Debug(e);
-                }
-            }
+            public TimeSpan Interval { get; } = TimeSpan.FromMilliseconds(50);
 
-            public void Run()
+            public void Execute()
             {
                 _sender.InternalSend();
                 _receiver.InternalReceive();

--- a/src/Omnius.Core.Tasks/IBatchAction.cs
+++ b/src/Omnius.Core.Tasks/IBatchAction.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -5,8 +6,8 @@ namespace Omnius.Core.Tasks
 {
     public interface IBatchAction
     {
-        ValueTask WaitAsync(CancellationToken cancellationToken = default);
+        TimeSpan Interval { get; }
 
-        void Run();
+        void Execute();
     }
 }

--- a/test/Omnius.Core.Net.Connections.Tests/Bridge/BrigdeConnectionTest.cs
+++ b/test/Omnius.Core.Net.Connections.Tests/Bridge/BrigdeConnectionTest.cs
@@ -20,7 +20,7 @@ namespace Omnius.Core.Net.Connections.Bridge
 
             var (socket1, socket2) = SocketHelper.GetSocketPair();
 
-            var batchActionDispatcher = new BatchActionDispatcher();
+            var batchActionDispatcher = new BatchActionDispatcher(TimeSpan.FromMilliseconds(10));
             var options = new BridgeConnectionOptions(1024 * 1024 * 256, null, null, batchActionDispatcher, BytesPool.Shared);
 
             await using var connection1 = new BridgeConnection(new SocketCap(socket1), options);

--- a/test/Omnius.Core.Net.Connections.Tests/Multiplexer/OmniConnectionMultiplexerTest.cs
+++ b/test/Omnius.Core.Net.Connections.Tests/Multiplexer/OmniConnectionMultiplexerTest.cs
@@ -30,7 +30,7 @@ namespace Omnius.Core.Net.Connections.Multiplexer
             var (clientSocket, serverSocket) = SocketHelper.GetSocketPair();
 
             var bytesPool = BytesPool.Shared;
-            var batchActionDispatcher = new BatchActionDispatcher();
+            var batchActionDispatcher = new BatchActionDispatcher(TimeSpan.FromMilliseconds(10));
 
             var bridgeConnectionOptions = new BridgeConnectionOptions(1024 * 1024 * 256, null, null, batchActionDispatcher, bytesPool);
             var clientBridgeConnection = new BridgeConnection(new SocketCap(clientSocket), bridgeConnectionOptions);

--- a/test/Omnius.Core.Net.Connections.Tests/Secure/OmniSecureConnectionTest.cs
+++ b/test/Omnius.Core.Net.Connections.Tests/Secure/OmniSecureConnectionTest.cs
@@ -17,7 +17,7 @@ namespace Omnius.Core.Net.Connections.Secure
 
             var (socket1, socket2) = SocketHelper.GetSocketPair();
 
-            var batchActionDispatcher = new BatchActionDispatcher();
+            var batchActionDispatcher = new BatchActionDispatcher(TimeSpan.FromMilliseconds(10));
             var options = new BridgeConnectionOptions(1024 * 1024 * 256, null, null, batchActionDispatcher, BytesPool.Shared);
 
             await using var bridgeConnection1 = new BridgeConnection(new SocketCap(socket1), options);

--- a/test/Omnius.Core.RocketPack.Remoting.Tests/RocketRemotingTest.cs
+++ b/test/Omnius.Core.RocketPack.Remoting.Tests/RocketRemotingTest.cs
@@ -21,7 +21,7 @@ namespace Omnius.Core.RocketPack.Remoting
             var (clientSocket, serverSocket) = SocketHelper.GetSocketPair();
 
             var bytesPool = BytesPool.Shared;
-            var batchActionDispatcher = new BatchActionDispatcher();
+            var batchActionDispatcher = new BatchActionDispatcher(TimeSpan.FromMilliseconds(10));
 
             var bridgeConnectionOptions = new BridgeConnectionOptions(1024 * 1024 * 256, null, null, batchActionDispatcher, bytesPool);
             await using var clientBridgeConnection = new BridgeConnection(new SocketCap(clientSocket), bridgeConnectionOptions);


### PR DESCRIPTION
改修前は、BatchActionのWaitAsyncでActionの実行まで待っていて、BatchActionの数だけTaskが実行されるのでコストが高かった。
改修後は、BatchActionDispatcherで指定したIntervalでBatchActionを監視し、BatchActionに指定されたIntervalを超えた場合にActionを実行するように変更した。
